### PR TITLE
fix missing scanner in builds

### DIFF
--- a/bindings/rust/build.rs
+++ b/bindings/rust/build.rs
@@ -13,11 +13,9 @@ fn main() {
     // If your language uses an external scanner written in C,
     // then include this block of code:
 
-    /*
     let scanner_path = src_dir.join("scanner.c");
     c_config.file(&scanner_path);
     println!("cargo:rerun-if-changed={}", scanner_path.to_str().unwrap());
-    */
 
     c_config.compile("parser");
     println!("cargo:rerun-if-changed={}", parser_path.to_str().unwrap());


### PR DESCRIPTION
since tree-sitter-cobol uses an external scanner, the rust crate's build script needs to compile that as well. this fixes the errors seen in builds of downstream libraries such as:

```
error: linking with `cc` failed: exit status: 1
    .
    .
    .
  = note: some `extern` functions couldn't be found; some native libraries may need to be installed or have their path specified
```