### PR TITLE
add support for cobol copybooks

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -31,11 +31,10 @@ module.exports = grammar({
   ],
 
   rules: {
-    start: $ => repeat(
-      choice(
-        $.program_definition,
-        //optional($.function_definition) //todo
-      )
+    start: $ => choice(
+      $.program_definition,
+      $.copybook_definition
+      //optional($.function_definition) //todo
     ),
 
     _comment: $ => /\*>[^\n]*/,
@@ -48,6 +47,10 @@ module.exports = grammar({
       repeat($.end_program), //todo
       //optional($.LINE_PREFIX_COMMENT),
     )),
+
+    copybook_definition: $ => repeat1(
+      seq($.data_description, repeat1('.'))
+    ),
 
     identification_division: $ => seq(
       $._IDENTIFICATION, $._DIVISION, '.',

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -3,16 +3,17 @@
   "word": "_WORD",
   "rules": {
     "start": {
-      "type": "REPEAT",
-      "content": {
-        "type": "CHOICE",
-        "members": [
-          {
-            "type": "SYMBOL",
-            "name": "program_definition"
-          }
-        ]
-      }
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "SYMBOL",
+          "name": "program_definition"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "copybook_definition"
+        }
+      ]
     },
     "_comment": {
       "type": "PATTERN",
@@ -69,6 +70,25 @@
             "content": {
               "type": "SYMBOL",
               "name": "end_program"
+            }
+          }
+        ]
+      }
+    },
+    "copybook_definition": {
+      "type": "REPEAT1",
+      "content": {
+        "type": "SEQ",
+        "members": [
+          {
+            "type": "SYMBOL",
+            "name": "data_description"
+          },
+          {
+            "type": "REPEAT1",
+            "content": {
+              "type": "STRING",
+              "value": "."
             }
           }
         ]

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -3373,6 +3373,21 @@
     }
   },
   {
+    "type": "copybook_definition",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": true,
+      "types": [
+        {
+          "type": "data_description",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
     "type": "crt_status_clause",
     "named": true,
     "fields": {},
@@ -12148,9 +12163,13 @@
     "named": true,
     "fields": {},
     "children": {
-      "multiple": true,
-      "required": false,
+      "multiple": false,
+      "required": true,
       "types": [
+        {
+          "type": "copybook_definition",
+          "named": true
+        },
         {
           "type": "program_definition",
           "named": true


### PR DESCRIPTION
this patchset adds support for cobol copybook syntax, allows parsing files of the form:

```cobol
      ******************************************************************
       01  SQLCA GLOBAL.
           05  SQLCAID               PIC X(8).
           05  SQLSTATE              PIC X(5).
      ******************************************************************

```

--- 

the patch also the `repeat` clause of the starting rule, is this `repeat` necessary? to allow empty programs, we can allow either program definitions or copybook definitions to contain 0 or more statements. i will mark the pr as a draft until this is resolved.