### PR TITLE
add support for `EXEC` directives

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -1398,6 +1398,7 @@ module.exports = grammar({
       $.use_statement,
       $.write_statement,
       $.next_sentence_statement,
+      $.execute_statement,
     ),
 
     _end_statement: $ => choice(
@@ -1421,6 +1422,8 @@ module.exports = grammar({
       $.END_START,
       $.END_STRING,
       $.END_UNSTRING,
+      $.END_EXECUTE,
+      $.END_EXEC,
       $.period
     ),
 
@@ -2712,6 +2715,20 @@ module.exports = grammar({
 
     next_sentence_statement: $ => seq($._NEXT, $._SENTENCE),
 
+    execute_statement: $ => seq($.execute_header, $.execute_body, $.execute_end),
+
+    execute_header: $ => choice(
+      $.EXEC,
+      $.EXECUTE,
+    ),
+
+    execute_body: $ => repeat1($.WORD),
+
+    execute_end: $ => choice(
+      $.END_EXECUTE,
+      $.END_EXEC,
+    ),
+
     _simple_value: $ => choice(
       $._identifier,
       $._basic_literal
@@ -2974,6 +2991,8 @@ module.exports = grammar({
     _END_SUBTRACT: $ => /[eE][nN][dD]-[sS][uU][bB][tT][rR][aA][cC][tT]/,
     _END_UNSTRING: $ => /[eE][nN][dD]-[uU][nN][sS][tT][rR][iI][nN][gG]/,
     _END_WRITE: $ => /[eE][nN][dD]-[wW][rR][iI][tT][eE]/,
+    _END_EXECUTE: $ => /[eE][nN][dD]-[eE][xX][eE][cC][uU][tT][eE]/,
+    _END_EXEC: $ => /[eE][nN][dD]-[eE][xX][eE][cC]/,
     _ENTRY: $ => /[eE][nN][tT][rR][yY]/,
     _ENVIRONMENT: $ => /[eE][nN][vV][iI][rR][oO][nN][mM][eE][nN][tT]/,
     _ENVIRONMENT_NAME: $ => /[eE][nN][vV][iI][rR][oO][nN][mM][eE][nN][tT]-[nN][aA][mM][eE]/,
@@ -3098,6 +3117,8 @@ module.exports = grammar({
     _NATIVE: $ => /[nN][aA][tT][iI][vV][eE]/,
     _NEGATIVE: $ => /[nN][eE][gG][aA][tT][iI][vV][eE]/,
     _NEXT: $ => /[nN][eE][xX][tT]/,
+    _EXECUTE: $ => /[eE][xX][eE][cC][uU][tT][eE]/,
+    _EXEC: $ => /[eE][xX][eE][cC]/,
     _NEXT_SENTENCE: $ => /[nN][eE][xX][tT]-[sS][eE][nN][tT][eE][nN][cC][eE]/,
     _NO: $ => /[nN][oO]/,
     _NOMINAL: $ => /[nN][oO][mM][iI][nN][aA][lL]/,
@@ -3440,6 +3461,8 @@ module.exports = grammar({
     END_SUBTRACT: $ => $._END_SUBTRACT,
     END_UNSTRING: $ => $._END_UNSTRING,
     END_WRITE: $ => $._END_WRITE,
+    END_EXECUTE: $ => $._END_EXECUTE,
+    END_EXEC: $ => $._END_EXEC,
     //ENTRY: $ => $._ENTRY,
     ENVIRONMENT: $ => $._ENVIRONMENT,
     //ENVIRONMENT_NAME: $ => $._ENVIRONMENT_NAME,
@@ -3550,6 +3573,8 @@ module.exports = grammar({
     ////NE: $ => $._NE,
     NEGATIVE: $ => $._NEGATIVE,
     NEXT: $ => $._NEXT,
+    EXECUTE: $ => $._EXECUTE,
+    EXEC: $ => $._EXEC,
     //NEXT_SENTENCE: $ => $._NEXT_SENTENCE,
     NO: $ => $._NO,
     //NOMINAL: $ => $._NOMINAL,

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -7161,6 +7161,10 @@
         {
           "type": "SYMBOL",
           "name": "next_sentence_statement"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "execute_statement"
         }
       ]
     },
@@ -7246,6 +7250,14 @@
         {
           "type": "SYMBOL",
           "name": "END_UNSTRING"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "END_EXECUTE"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "END_EXEC"
         },
         {
           "type": "SYMBOL",
@@ -15366,6 +15378,56 @@
         }
       ]
     },
+    "execute_statement": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "SYMBOL",
+          "name": "execute_header"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "execute_body"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "execute_end"
+        }
+      ]
+    },
+    "execute_header": {
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "SYMBOL",
+          "name": "EXEC"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "EXECUTE"
+        }
+      ]
+    },
+    "execute_body": {
+      "type": "REPEAT1",
+      "content": {
+        "type": "SYMBOL",
+        "name": "WORD"
+      }
+    },
+    "execute_end": {
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "SYMBOL",
+          "name": "END_EXECUTE"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "END_EXEC"
+        }
+      ]
+    },
     "_simple_value": {
       "type": "CHOICE",
       "members": [
@@ -16724,6 +16786,14 @@
       "type": "PATTERN",
       "value": "[eE][nN][dD]-[wW][rR][iI][tT][eE]"
     },
+    "_END_EXECUTE": {
+      "type": "PATTERN",
+      "value": "[eE][nN][dD]-[eE][xX][eE][cC][uU][tT][eE]"
+    },
+    "_END_EXEC": {
+      "type": "PATTERN",
+      "value": "[eE][nN][dD]-[eE][xX][eE][cC]"
+    },
     "_ENTRY": {
       "type": "PATTERN",
       "value": "[eE][nN][tT][rR][yY]"
@@ -17305,6 +17375,14 @@
     "_NEXT": {
       "type": "PATTERN",
       "value": "[nN][eE][xX][tT]"
+    },
+    "_EXECUTE": {
+      "type": "PATTERN",
+      "value": "[eE][xX][eE][cC][uU][tT][eE]"
+    },
+    "_EXEC": {
+      "type": "PATTERN",
+      "value": "[eE][xX][eE][cC]"
     },
     "_NEXT_SENTENCE": {
       "type": "PATTERN",
@@ -18495,6 +18573,14 @@
       "type": "SYMBOL",
       "name": "_END_WRITE"
     },
+    "END_EXECUTE": {
+      "type": "SYMBOL",
+      "name": "_END_EXECUTE"
+    },
+    "END_EXEC": {
+      "type": "SYMBOL",
+      "name": "_END_EXEC"
+    },
     "ENVIRONMENT": {
       "type": "SYMBOL",
       "name": "_ENVIRONMENT"
@@ -18682,6 +18768,14 @@
     "NEXT": {
       "type": "SYMBOL",
       "name": "_NEXT"
+    },
+    "EXECUTE": {
+      "type": "SYMBOL",
+      "name": "_EXECUTE"
+    },
+    "EXEC": {
+      "type": "SYMBOL",
+      "name": "_EXEC"
     },
     "NO": {
       "type": "SYMBOL",

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -335,6 +335,16 @@
     "fields": {}
   },
   {
+    "type": "END_EXEC",
+    "named": true,
+    "fields": {}
+  },
+  {
+    "type": "END_EXECUTE",
+    "named": true,
+    "fields": {}
+  },
+  {
     "type": "END_IF",
     "named": true,
     "fields": {}
@@ -426,6 +436,16 @@
   },
   {
     "type": "EXCLUSIVE",
+    "named": true,
+    "fields": {}
+  },
+  {
+    "type": "EXEC",
+    "named": true,
+    "fields": {}
+  },
+  {
+    "type": "EXECUTE",
     "named": true,
     "fields": {}
   },
@@ -4500,6 +4520,82 @@
       "types": [
         {
           "type": "qualified_word",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "execute_body",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": true,
+      "types": [
+        {
+          "type": "WORD",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "execute_end",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": false,
+      "required": true,
+      "types": [
+        {
+          "type": "END_EXEC",
+          "named": true
+        },
+        {
+          "type": "END_EXECUTE",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "execute_header",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": false,
+      "required": true,
+      "types": [
+        {
+          "type": "EXEC",
+          "named": true
+        },
+        {
+          "type": "EXECUTE",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "execute_statement",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": true,
+      "types": [
+        {
+          "type": "execute_body",
+          "named": true
+        },
+        {
+          "type": "execute_end",
+          "named": true
+        },
+        {
+          "type": "execute_header",
           "named": true
         }
       ]
@@ -9229,6 +9325,14 @@
           "named": true
         },
         {
+          "type": "END_EXEC",
+          "named": true
+        },
+        {
+          "type": "END_EXECUTE",
+          "named": true
+        },
+        {
           "type": "END_IF",
           "named": true
         },
@@ -9342,6 +9446,10 @@
         },
         {
           "type": "evaluate_header",
+          "named": true
+        },
+        {
+          "type": "execute_statement",
           "named": true
         },
         {
@@ -9556,6 +9664,14 @@
           "named": true
         },
         {
+          "type": "END_EXEC",
+          "named": true
+        },
+        {
+          "type": "END_EXECUTE",
+          "named": true
+        },
+        {
           "type": "END_IF",
           "named": true
         },
@@ -9669,6 +9785,10 @@
         },
         {
           "type": "evaluate_header",
+          "named": true
+        },
+        {
+          "type": "execute_statement",
           "named": true
         },
         {


### PR DESCRIPTION
attempts to parse `exec` statements as described here: https://github.com/yutaro-sakamoto/tree-sitter-cobol/issues/6#issuecomment-1877322262.

---

i understand that this may not be the vision for this project, in which case, i'd be happy to try my hand at rich-sql parsing to suppor esql statements.