### PR TITLE
chore: update tests

### DIFF
--- a/test/corpus/data_description.txt
+++ b/test/corpus/data_description.txt
@@ -18,6 +18,7 @@ file-section
        PROCEDURE DIVISION.
        DISPLAY 1.
 ---
+
 (start
   (program_definition
     (identification_division
@@ -55,7 +56,9 @@ file-section
     (procedure_division
       (display_statement
         (number
-          (integer))))))
+          (integer)))
+      (period))))
+
 ====================================
 value clause
 ====================================
@@ -66,6 +69,7 @@ value clause
        77  A06THREES-DS-03V03          PICTURE S999V999 VALUE 333.333.  
        PROCEDURE DIVISION.
 ---
+
 (start
   (program_definition
     (identification_division
@@ -78,8 +82,9 @@ value clause
           (picture_clause
             (picture_9))
           (value_clause
-            (number
-              (decimal))))))
+            (value_item
+              (number
+                (decimal)))))))
     (procedure_division)))
 
 ====================================
@@ -92,6 +97,7 @@ picture decimal
        77  A06THREES-DS-03V03     PICTURE SV9(5) VALUE .11111.
        PROCEDURE DIVISION.
 ---
+
 (start
   (program_definition
     (identification_division
@@ -104,9 +110,11 @@ picture decimal
           (picture_clause
             (picture_9))
           (value_clause
-            (number
-              (decimal))))))
+            (value_item
+              (number
+                (decimal)))))))
     (procedure_division)))
+
 ====================================
 computational
 ====================================
@@ -117,6 +125,7 @@ computational
        77  A06THREES-DS-03V03     PICTURE SV9(5) COMPUTATIONAL.
        PROCEDURE DIVISION.
 ---
+
 (start
   (program_definition
     (identification_division

--- a/test/corpus/evaluate.txt
+++ b/test/corpus/evaluate.txt
@@ -10,25 +10,29 @@ evaluate when
        end-evaluate.
        aa.
 ---
+
 (start
   (program_definition
     (identification_division
       (program_name))
     (procedure_division
-      (evaluate_statement
-        subjects: (evaluate_subject
+      (evaluate_header
+        (evaluate_subject
           (expr
             (number
-              (integer))))
-        cases: (evaluate_case
-          when: (expr
-            (number
-              (integer)))
-          statements: (goto_statement
-            to: (label
-              (qualified_word
-                (WORD))))))
+              (integer)))))
+      (when
+        (expr
+          (number
+            (integer))))
+      (goto_statement
+        to: (label
+          (qualified_word
+            (WORD))))
+      (END_EVALUATE)
+      (period)
       (paragraph_header))))
+
 ====================================
 evaluate when 2
 ====================================
@@ -43,33 +47,37 @@ evaluate when 2
        end-evaluate.
        aa.
 ---
+
 (start
   (program_definition
     (identification_division
       (program_name))
     (procedure_division
-      (evaluate_statement
-        subjects: (evaluate_subject
+      (evaluate_header
+        (evaluate_subject
           (expr
             (number
-              (integer))))
-        cases: (evaluate_case
-          when: (expr
-            (number
-              (integer)))
-          statements: (goto_statement
-            to: (label
-              (qualified_word
-                (WORD)))))
-        cases: (evaluate_case
-          when: (expr
-            (number
-              (integer)))
-          statements: (goto_statement
-            to: (label
-              (qualified_word
-                (WORD))))))
+              (integer)))))
+      (when
+        (expr
+          (number
+            (integer))))
+      (goto_statement
+        to: (label
+          (qualified_word
+            (WORD))))
+      (when
+        (expr
+          (number
+            (integer))))
+      (goto_statement
+        to: (label
+          (qualified_word
+            (WORD))))
+      (END_EVALUATE)
+      (period)
       (paragraph_header))))
+
 ====================================
 evaluate when other
 ====================================
@@ -86,38 +94,42 @@ evaluate when other
        end-evaluate.
        aa.
 ---
+
 (start
   (program_definition
     (identification_division
       (program_name))
     (procedure_division
-      (evaluate_statement
-        subjects: (evaluate_subject
+      (evaluate_header
+        (evaluate_subject
           (expr
             (number
-              (integer))))
-        cases: (evaluate_case
-          when: (expr
-            (number
-              (integer)))
-          statements: (goto_statement
-            to: (label
-              (qualified_word
-                (WORD)))))
-        cases: (evaluate_case
-          when: (expr
-            (number
-              (integer)))
-          statements: (goto_statement
-            to: (label
-              (qualified_word
-                (WORD)))))
-        other: (evaluate_other
-          statement: (goto_statement
-            to: (label
-              (qualified_word
-                (WORD))))))
+              (integer)))))
+      (when
+        (expr
+          (number
+            (integer))))
+      (goto_statement
+        to: (label
+          (qualified_word
+            (WORD))))
+      (when
+        (expr
+          (number
+            (integer))))
+      (goto_statement
+        to: (label
+          (qualified_word
+            (WORD))))
+      (when_other)
+      (goto_statement
+        to: (label
+          (qualified_word
+            (WORD))))
+      (END_EVALUATE)
+      (period)
       (paragraph_header))))
+
 ====================================
 evaluate when when
 ====================================
@@ -131,28 +143,32 @@ evaluate when when
        end-evaluate.
        aa.
 ---
+
 (start
   (program_definition
     (identification_division
       (program_name))
     (procedure_division
-      (evaluate_statement
-        subjects: (evaluate_subject
+      (evaluate_header
+        (evaluate_subject
           (expr
             (number
-              (integer))))
-        cases: (evaluate_case
-          when: (expr
-            (number
-              (integer)))
-          when: (expr
-            (number
-              (integer)))
-          statements: (goto_statement
-            to: (label
-              (qualified_word
-                (WORD))))))
+              (integer)))))
+      (when
+        (expr
+          (number
+            (integer)))
+        (expr
+          (number
+            (integer))))
+      (goto_statement
+        to: (label
+          (qualified_word
+            (WORD))))
+      (END_EVALUATE)
+      (period)
       (paragraph_header))))
+
 ====================================
 evaluate when also
 ====================================
@@ -165,29 +181,32 @@ evaluate when also
        end-evaluate.
        aa.
 ---
+
 (start
   (program_definition
     (identification_division
       (program_name))
     (procedure_division
-      (evaluate_statement
-        subjects: (evaluate_subject
+      (evaluate_header
+        (evaluate_subject
           (expr
             (number
               (integer))))
-        subjects: (evaluate_subject
+        (evaluate_subject
           (expr
             (number
-              (integer))))
-        cases: (evaluate_case
-          when: (expr
-            (number
-              (integer)))
-          when: (expr
-            (number
-              (integer)))
-          statements: (goto_statement
-            to: (label
-              (qualified_word
-                (WORD))))))
+              (integer)))))
+      (when
+        (expr
+          (number
+            (integer)))
+        (expr
+          (number
+            (integer))))
+      (goto_statement
+        to: (label
+          (qualified_word
+            (WORD))))
+      (END_EVALUATE)
+      (period)
       (paragraph_header))))

--- a/test/corpus/file.txt
+++ b/test/corpus/file.txt
@@ -10,6 +10,7 @@ open input
        procedure division.
        open input f.
 ---
+
 (start
   (program_definition
     (identification_division
@@ -24,7 +25,9 @@ open input
       (open_statement
         (open_arg
           mode: (INPUT)
-          file_name_list: (WORD))))))
+          file_name_list: (WORD)))
+      (period))))
+
 ====================================
 open output
 ====================================
@@ -37,6 +40,7 @@ open output
        procedure division.
        open output f.
 ---
+
 (start
   (program_definition
     (identification_division
@@ -51,7 +55,9 @@ open output
       (open_statement
         (open_arg
           mode: (OUTPUT)
-          file_name_list: (WORD))))))
+          file_name_list: (WORD)))
+      (period))))
+
 ====================================
 open i-o
 ====================================
@@ -64,6 +70,7 @@ open i-o
        procedure division.
        open i-o f.
 ---
+
 (start
   (program_definition
     (identification_division
@@ -78,7 +85,9 @@ open i-o
       (open_statement
         (open_arg
           mode: (I_O)
-          file_name_list: (WORD))))))
+          file_name_list: (WORD)))
+      (period))))
+
 ====================================
 open extend
 ====================================
@@ -91,6 +100,7 @@ open extend
        procedure division.
        open extend f.
 ---
+
 (start
   (program_definition
     (identification_division
@@ -105,7 +115,9 @@ open extend
       (open_statement
         (open_arg
           mode: (EXTEND)
-          file_name_list: (WORD))))))
+          file_name_list: (WORD)))
+      (period))))
+
 ====================================
 close
 ====================================
@@ -118,6 +130,7 @@ close
        procedure division.
        close f.
 ---
+
 (start
   (program_definition
     (identification_division
@@ -131,7 +144,9 @@ close
     (procedure_division
       (close_statement
         (close_arg
-          file_handler: (WORD))))))
+          file_handler: (WORD)))
+      (period))))
+
 ====================================
 close reel
 ====================================
@@ -144,6 +159,7 @@ close reel
        procedure division.
        close f reel.
 ---
+
 (start
   (program_definition
     (identification_division
@@ -159,7 +175,9 @@ close reel
         (close_arg
           file_handler: (WORD)
           (close_option
-            (REEL)))))))
+            (REEL))))
+      (period))))
+
 ====================================
 close unit
 ====================================
@@ -172,6 +190,7 @@ close unit
        procedure division.
        close f UNIT.
 ---
+
 (start
   (program_definition
     (identification_division
@@ -187,7 +206,9 @@ close unit
         (close_arg
           file_handler: (WORD)
           (close_option
-            (UNIT)))))))
+            (UNIT))))
+      (period))))
+
 ====================================
 close unit removal
 ====================================
@@ -200,6 +221,7 @@ close unit removal
        procedure division.
        close f unit removal.
 ---
+
 (start
   (program_definition
     (identification_division
@@ -216,7 +238,9 @@ close unit removal
           file_handler: (WORD)
           (close_option
             (UNIT)
-            (REMOVAL)))))))
+            (REMOVAL))))
+      (period))))
+
 ====================================
 close unit for removal
 ====================================
@@ -229,6 +253,7 @@ close unit for removal
        procedure division.
        close f unit for removal.
 ---
+
 (start
   (program_definition
     (identification_division
@@ -245,7 +270,9 @@ close unit for removal
           file_handler: (WORD)
           (close_option
             (UNIT)
-            (REMOVAL)))))))
+            (REMOVAL))))
+      (period))))
+
 ====================================
 close unit no rewind
 ====================================
@@ -258,6 +285,7 @@ close unit no rewind
        procedure division.
        close f no rewind. 
 ---
+
 (start
   (program_definition
     (identification_division
@@ -274,7 +302,9 @@ close unit no rewind
           file_handler: (WORD)
           (close_option
             (NO)
-            (REWIND)))))))
+            (REWIND))))
+      (period))))
+
 ====================================
 close unit with no rewind
 ====================================
@@ -287,6 +317,7 @@ close unit with no rewind
        procedure division.
        close f with no rewind. 
 ---
+
 (start
   (program_definition
     (identification_division
@@ -303,7 +334,9 @@ close unit with no rewind
           file_handler: (WORD)
           (close_option
             (NO)
-            (REWIND)))))))
+            (REWIND))))
+      (period))))
+
 ====================================
 close unit lock
 ====================================
@@ -316,6 +349,7 @@ close unit lock
        procedure division.
        close f lock. 
 ---
+
 (start
   (program_definition
     (identification_division
@@ -331,7 +365,9 @@ close unit lock
         (close_arg
           file_handler: (WORD)
           (close_option
-            (LOCK)))))))
+            (LOCK))))
+      (period))))
+
 ====================================
 close unit with lock
 ====================================
@@ -344,6 +380,7 @@ close unit with lock
        procedure division.
        close f with lock. 
 ---
+
 (start
   (program_definition
     (identification_division
@@ -359,4 +396,5 @@ close unit with lock
         (close_arg
           file_handler: (WORD)
           (close_option
-            (LOCK)))))))
+            (LOCK))))
+      (period))))

--- a/test/corpus/goto.txt
+++ b/test/corpus/goto.txt
@@ -8,7 +8,8 @@ go
          go aa.
        bb.
 ---
-(start 
+
+(start
   (program_definition
     (identification_division
       (program_name))
@@ -18,7 +19,9 @@ go
         to: (label
           (qualified_word
             (WORD))))
+      (period)
       (paragraph_header))))
+
 ====================================
 go to
 ====================================
@@ -29,7 +32,8 @@ go to
          go to aa.
        bb.
 ---
-(start 
+
+(start
   (program_definition
     (identification_division
       (program_name))
@@ -39,7 +43,9 @@ go to
         to: (label
           (qualified_word
             (WORD))))
+      (period)
       (paragraph_header))))
+
 ====================================
 go to depending
 ====================================
@@ -53,6 +59,7 @@ go to depending
        bb-1.
        bb-2.
 ---
+
 (start
   (program_definition
     (identification_division
@@ -74,8 +81,10 @@ go to depending
             (WORD)))
         depending: (qualified_word
           (WORD)))
+      (period)
       (paragraph_header)
       (paragraph_header))))
+
 ====================================
 go to depending on
 ====================================
@@ -89,6 +98,7 @@ go to depending on
        bb-1.
        bb-2.
 ---
+
 (start
   (program_definition
     (identification_division
@@ -110,8 +120,10 @@ go to depending on
             (WORD)))
         depending: (qualified_word
           (WORD)))
+      (period)
       (paragraph_header)
       (paragraph_header))))
+
 ====================================
 go string
 ====================================
@@ -122,7 +134,8 @@ go string
          go "bb".
        bb.
 ---
-(start 
+
+(start
   (program_definition
     (identification_division
       (program_name))
@@ -131,7 +144,9 @@ go string
       (goto_statement
         to: (label
           (string)))
+      (period)
       (paragraph_header))))
+
 ====================================
 go string of string
 ====================================
@@ -143,7 +158,8 @@ go string of string
        cc section.
        bb.
 ---
-(start 
+
+(start
   (program_definition
     (identification_division
       (program_name))
@@ -153,5 +169,6 @@ go string of string
         to: (label
           (string)
           (string)))
+      (period)
       (section_header)
       (paragraph_header))))

--- a/test/corpus/minimal-cobol.txt
+++ b/test/corpus/minimal-cobol.txt
@@ -16,4 +16,6 @@ Minimal COBOL program
       (program_name))
     (procedure_division
       (stop_statement)
-      (stop_statement))))
+      (period)
+      (stop_statement)
+      (period))))

--- a/test/corpus/perform.txt
+++ b/test/corpus/perform.txt
@@ -7,6 +7,7 @@ perform label
        perform aa.
        aa.
 ---
+
 (start
   (program_definition
     (identification_division
@@ -17,7 +18,9 @@ perform label
           (label
             (qualified_word
               (WORD)))))
+      (period)
       (paragraph_header))))
+
 ====================================
 perform label thru label
 ====================================
@@ -28,6 +31,7 @@ perform label thru label
        aa.
        bb.
 ---
+
 (start
   (program_definition
     (identification_division
@@ -38,12 +42,14 @@ perform label thru label
           (label
             (qualified_word
               (WORD)))
-           (THRU)
+          (THRU)
           (label
             (qualified_word
               (WORD)))))
+      (period)
       (paragraph_header)
       (paragraph_header))))
+
 ====================================
 perform label FOREVER
 ====================================
@@ -53,6 +59,7 @@ perform label FOREVER
        perform aa forever.
        aa.
 ---
+
 (start
   (program_definition
     (identification_division
@@ -65,7 +72,9 @@ perform label FOREVER
               (WORD))))
         option: (perform_option
           (FOREVER)))
+      (period)
       (paragraph_header))))
+
 ====================================
 perform continue
 ====================================
@@ -76,6 +85,7 @@ perform continue
          continue
        end-perform.
 ---
+
 (start
   (program_definition
     (identification_division
@@ -83,8 +93,11 @@ perform continue
     (procedure_division
       (perform_statement_loop
         option: (perform_option
-          (FOREVER))
-        statements: (continue_statement)))))
+          (FOREVER)))
+      (continue_statement)
+      (END_PERFORM)
+      (period))))
+
 ====================================
 perform label times
 ====================================
@@ -94,6 +107,7 @@ perform label times
        perform aa 3 times.
        aa.
 ---
+
 (start
   (program_definition
     (identification_division
@@ -106,8 +120,10 @@ perform label times
               (WORD))))
         option: (perform_option
           times: (number
-              (integer))))
+            (integer))))
+      (period)
       (paragraph_header))))
+
 ====================================
 perform label UNTIL
 ====================================
@@ -120,6 +136,7 @@ perform label UNTIL
        perform aa varying c FROM 1 BY 1 UNTIL c >= 1.
        aa.
 ---
+
 (start
   (program_definition
     (identification_division
@@ -151,4 +168,5 @@ perform label UNTIL
               (ge)
               (number
                 (integer))))))
+      (period)
       (paragraph_header))))


### PR DESCRIPTION
I work on [semgrep](https://github.com/semgrep/semgrep), an open-source static analysis tool, and we use the included `test/corpus` test cases as benchmarks when determining if we are properly supporting a language.

These test cases are out of date (seemingly since tests were [turned off in CI two years ago](https://github.com/yutaro-sakamoto/tree-sitter-cobol/commit/f9fe41fc8ac9ca5ed870c9aed8ca9c51fba06073)), so this PR simply runs `tree-sitter test -u` to have them be up to date. Since these tests aren't run in `tree-sitter-cobol`, this causes no harm to the repository.